### PR TITLE
Add Category model

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,15 @@
 class Category < ApplicationRecord
-  has_many :subcategories, class_name: "Category", foreign_key: "parent_id", dependent: :destroy
-  belongs_to :parent_category, class_name: "Category", foreign_key: "parent_id", optional: true
+  has_many :subcategories,
+           class_name: "Category",
+           foreign_key: "parent_id",
+           dependent: :destroy,
+           inverse_of: :parent_category
 
-  has_and_belongs_to_many :products
+  belongs_to :parent_category,
+             class_name: "Category",
+             foreign_key: "parent_id",
+             optional: true,
+             inverse_of: :subcategories
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,8 @@
+class Category < ApplicationRecord
+  has_many :subcategories, class_name: "Category", foreign_key: "parent_id", dependent: :destroy
+  belongs_to :parent_category, class_name: "Category", foreign_key: "parent_id", optional: true
+
+  has_and_belongs_to_many :products
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20241209181438_create_categories.rb
+++ b/db/migrate/20241209181438_create_categories.rb
@@ -1,0 +1,13 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.integer :parent_id, index: true
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_06_223730) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_09_181438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "parent_id"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "name"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    name { Faker::Commerce.department(max: 1, fixed_amount: true) }
+    parent_category { nil }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  subject { described_class.new(name: "Electronics") }
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name) }
+  it { should belong_to(:parent_category).optional }
+  it { should have_many(:subcategories).dependent(:destroy) }
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Category, type: :model do
   subject { described_class.new(name: "Electronics") }
-  it { should validate_presence_of(:name) }
-  it { should validate_uniqueness_of(:name) }
-  it { should belong_to(:parent_category).optional }
-  it { should have_many(:subcategories).dependent(:destroy) }
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to belong_to(:parent_category).optional }
+  it { is_expected.to have_many(:subcategories).dependent(:destroy) }
 end


### PR DESCRIPTION
## Issue
Closes #29 

## Description
This PR implements the `Category` model as part of the Categories Feature. The model introduces self-referential associations to support parent-child relationships and adds validations for data integrity.

## Scope
- **Goal:** Create a scalable `Category` model that supports hierarchical categorization.
- **Affected Areas:** 
  - Database schema
  - Model layer
  - Factory for testing
  - Model specs

## Implementation Details
- Created a `categories` table with the following attributes:
  - `name`: Required, unique.
  - `parent_id`: Optional, for self-referential relationships.
  - `description`: Optional.
- Added validations for `name` presence and uniqueness.
- Established self-referential associations (`parent_category`, `subcategories`).
- Added a factory for generating test categories using `Faker`.
- Wrote model specs to test validations and associations.

## How Has This Been Tested?
- [x] Unit tests added for:
  - Validations (`name` presence, uniqueness).
  - Associations (self-referential, `parent_category` and `subcategories`).
- [x] Factory tested

## Checklist
- [x] Feature meets acceptance criteria
- [x] Tests are added and pass
- [x] Code follows project style guidelines
- [x] Documentation updated if needed
