### PR TITLE
Add join table for Categories and Products

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,7 @@
 class Category < ApplicationRecord
+  has_many :category_products, dependent: :destroy
+  has_many :products, through: :category_products
+
   has_many :subcategories,
            class_name: "Category",
            foreign_key: "parent_id",

--- a/app/models/category_product.rb
+++ b/app/models/category_product.rb
@@ -1,0 +1,6 @@
+class CategoryProduct < ApplicationRecord
+  belongs_to :category
+  belongs_to :product
+
+  validates :category_id, uniqueness: { scope: :product_id }
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,7 @@
 class Product < ApplicationRecord
+  has_many :category_products, dependent: :destroy
+  has_many :categories, through: :category_products
+
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/db/migrate/20241216232255_create_category_products.rb
+++ b/db/migrate/20241216232255_create_category_products.rb
@@ -1,0 +1,12 @@
+class CreateCategoryProducts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :category_products do |t|
+      t.references :category, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :category_products, [:category_id, :product_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_181438) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_232255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_181438) do
     t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
+  create_table "category_products", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id", "product_id"], name: "index_category_products_on_category_id_and_product_id", unique: true
+    t.index ["category_id"], name: "index_category_products_on_category_id"
+    t.index ["product_id"], name: "index_category_products_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -33,4 +43,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_181438) do
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_products_on_name", unique: true
   end
+
+  add_foreign_key "category_products", "categories"
+  add_foreign_key "category_products", "products"
 end

--- a/spec/factories/category_products.rb
+++ b/spec/factories/category_products.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category_product do
+    category
+    product
+  end
+end

--- a/spec/models/category_product_spec.rb
+++ b/spec/models/category_product_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe CategoryProduct, type: :model do
+  subject { build(:category_product, category: category, product: product) }
+
   let(:category) { create(:category) }
   let(:product) { create(:product) }
-
-  subject { build(:category_product, category: category, product: product) }
 
   it { is_expected.to belong_to(:category) }
   it { is_expected.to belong_to(:product) }
 
   it "validates uniqueness of category_id scoped to product_id" do
     create(:category_product, category: category, product: product)
-    is_expected.to validate_uniqueness_of(:category_id).scoped_to(:product_id)
+    expect(subject).to validate_uniqueness_of(:category_id).scoped_to(:product_id)
   end
 end

--- a/spec/models/category_product_spec.rb
+++ b/spec/models/category_product_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe CategoryProduct, type: :model do
+  let(:category) { create(:category) }
+  let(:product) { create(:product) }
+
+  subject { build(:category_product, category: category, product: product) }
+
+  it { is_expected.to belong_to(:category) }
+  it { is_expected.to belong_to(:product) }
+
+  it "validates uniqueness of category_id scoped to product_id" do
+    create(:category_product, category: category, product: product)
+    is_expected.to validate_uniqueness_of(:category_id).scoped_to(:product_id)
+  end
+end

--- a/spec/models/category_product_spec.rb
+++ b/spec/models/category_product_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CategoryProduct, type: :model do
-  subject { build(:category_product, category: category, product: product) }
+  subject(:cat_prod) { build(:category_product, category: category, product: product) }
 
   let(:category) { create(:category) }
   let(:product) { create(:product) }
@@ -11,6 +11,6 @@ RSpec.describe CategoryProduct, type: :model do
 
   it "validates uniqueness of category_id scoped to product_id" do
     create(:category_product, category: category, product: product)
-    expect(subject).to validate_uniqueness_of(:category_id).scoped_to(:product_id)
+    expect(cat_prod).to validate_uniqueness_of(:category_id).scoped_to(:product_id)
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,4 +7,5 @@ RSpec.describe Category, type: :model do
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to belong_to(:parent_category).optional }
   it { is_expected.to have_many(:subcategories).dependent(:destroy) }
+  it { is_expected.to have_many(:products).through(:category_products) }
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe Product, type: :model do
     it { is_expected.to validate_numericality_of(:price).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_presence_of(:stock_quantity) }
     it { is_expected.to validate_numericality_of(:stock_quantity).only_integer.is_greater_than_or_equal_to(0) }
+    it { is_expected.to have_many(:categories).through(:category_products) }
   end
 end


### PR DESCRIPTION
https://github.com/PhilipDeFraties/scalecart-backend/issues/30

## Feature Description

Introduces a join table to establish a many-to-many relationship between `categories` and `products`. The `CategoryProduct` model is added to facilitate the relationship, and appropriate validations and tests are included to ensure data integrity.

### Feature Scope

- **Goal:** Enable many-to-many relationships between `categories` and `products` using a `has_many :through` association.

- **Affected Areas:** 
  - Database schema
  - Models (`Category`, `Product`, `CategoryProduct`)
  - Model tests and factories

### Implementation Details

- **Database Migration:**
  - Created `category_products` table with `category_id` and `product_id` columns.
  - Added a unique index on `category_id` and `product_id` to prevent duplicate entries.
- **Model Updates:**
  - `Category` and `Product` updated to use `has_many :through` associations via `CategoryProduct`.
  - `CategoryProduct` validates uniqueness of `category_id` scoped to `product_id`.
- **Factories:**
  - Added `category_product` factory to generate valid test data.
- **Tests:**
  - Added model tests for `Category`, `Product`, and `CategoryProduct` to validate associations and uniqueness constraints.

### How Has This Been Tested?

- [x] Unit tests for:
  - `Category` and `Product` `has_many :through` associations.
  - `CategoryProduct` validations, including uniqueness of `category_id` scoped to `product_id`.
- [x] Verified the migration creates the table correctly with unique constraints.

### Checklist

- [x] Feature meets acceptance criteria
- [x] Tests are added and pass
- [x] Code follows project style guidelines
- [x] Documentation updated if needed
