### PR TITLE
feat(controller): add CategoriesController with CRUD actions

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,51 @@
+class CategoriesController < ApplicationController
+  before_action :set_category, only: %i[show update destroy]
+
+  # GET /categories
+  def index
+    categories = Category.all
+    render json: categories, status: :ok
+  end
+
+  # GET /categories/:id
+  def show
+    render json: @category, include: :subcategories, status: :ok
+  end
+
+  # POST /categories
+  def create
+    category = Category.new(category_params)
+    if category.save
+      render json: category, status: :created
+    else
+      render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PUT /categories/:id
+  def update
+    if @category.update(category_params)
+      render json: @category, status: :ok
+    else
+      render json: { errors: @category.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /categories/:id
+  def destroy
+    @category.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_category
+    @category = Category.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Couldn't find Category with 'id'=#{params[:id]}" }, status: :not_found
+  end
+
+  def category_params
+    params.require(:category).permit(:name, :description, :parent_id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  resources :products
+  resources :products, only: %i[index show create update destroy]
+  resources :categories, only: %i[index show create update destroy]
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :category do
-    name { Faker::Commerce.department(max: 1, fixed_amount: true) }
+    sequence(:name) { |n| "Category #{n}" }
     parent_category { nil }
   end
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe "Categories API", type: :request do
 
     context "with valid attributes" do
       it "creates a new category" do
-        expect {
+        expect do
           post '/categories', params: { category: valid_attributes }
-        }.to change(Category, :count).by(1)
+        end.to change(Category, :count).by(1)
 
         expect(response).to have_http_status(:created)
         body = JSON.parse(response.body)
@@ -102,9 +102,9 @@ RSpec.describe "Categories API", type: :request do
   describe "DELETE /categories/:id" do
     context "when the category exists" do
       it "deletes the category" do
-        expect {
+        expect do
           delete "/categories/#{category_id}"
-        }.to change(Category, :count).by(-1)
+        end.to change(Category, :count).by(-1)
 
         expect(response).to have_http_status(:no_content)
       end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe "Categories API", type: :request do
+  let!(:categories) { create_list(:category, 5) }
+  let(:category_id) { categories.first.id }
+
+  describe "GET /categories" do
+    it "returns all categories" do
+      get '/categories'
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).size).to eq(5)
+    end
+  end
+
+  describe "GET /categories/:id" do
+    context "when the category exists" do
+      it "returns the category" do
+        get "/categories/#{category_id}"
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['id']).to eq(category_id)
+        expect(body['name']).to eq(categories.first.name)
+      end
+    end
+
+    context "when the category does not exist" do
+      it "returns a 404 not found" do
+        get "/categories/99999"
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Couldn't find Category with 'id'=99999")
+      end
+    end
+  end
+
+  describe "POST /categories" do
+    let(:valid_attributes) { { name: "New Category", description: "A new category" } }
+    let(:invalid_attributes) { { name: "" } }
+
+    context "with valid attributes" do
+      it "creates a new category" do
+        expect {
+          post '/categories', params: { category: valid_attributes }
+        }.to change(Category, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = JSON.parse(response.body)
+        expect(body['name']).to eq("New Category")
+      end
+    end
+
+    context "with invalid attributes" do
+      it "returns a 422 unprocessable entity" do
+        post '/categories', params: { category: invalid_attributes }
+
+        expect(response).to have_http_status(422)
+        body = JSON.parse(response.body)
+        expect(body['errors']).to include("Name can't be blank")
+      end
+    end
+  end
+
+  describe "PUT /categories/:id" do
+    let(:valid_attributes) { { name: "Updated Category" } }
+    let(:invalid_attributes) { { name: "" } }
+
+    context "when the category exists" do
+      it "updates the category" do
+        put "/categories/#{category_id}", params: { category: valid_attributes }
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['name']).to eq("Updated Category")
+        expect(Category.find(category_id).name).to eq("Updated Category")
+      end
+    end
+
+    context "when the category does not exist" do
+      it "returns a 404 not found" do
+        put "/categories/99999", params: { category: valid_attributes }
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Couldn't find Category with 'id'=99999")
+      end
+    end
+
+    context "with invalid attributes" do
+      it "returns a 422 unprocessable entity" do
+        put "/categories/#{category_id}", params: { category: invalid_attributes }
+
+        expect(response).to have_http_status(422)
+        body = JSON.parse(response.body)
+        expect(body['errors']).to include("Name can't be blank")
+      end
+    end
+  end
+
+  describe "DELETE /categories/:id" do
+    context "when the category exists" do
+      it "deletes the category" do
+        expect {
+          delete "/categories/#{category_id}"
+        }.to change(Category, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "when the category does not exist" do
+      it "returns a 404 not found" do
+        delete "/categories/99999"
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Couldn't find Category with 'id'=99999")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #31 

# Pull Request: Implement Categories API Endpoints

## Description
This pull request adds the full implementation of the Categories API, enabling CRUD operations for managing categories. It introduces the `CategoriesController` with actions for retrieving, creating, updating, and deleting categories. Request specs are included to ensure endpoint functionality and reliability.

## Scope
- **Goal:** Provide API endpoints for managing categories in the application.
- **Endpoints Implemented:**
  - `GET /categories`: Retrieve all categories.
  - `GET /categories/:id`: Retrieve a specific category, including its subcategories.
  - `POST /categories`: Create a new category.
  - `PUT /categories/:id`: Update an existing category.
  - `DELETE /categories/:id`: Delete a category.
- **Affected Areas:**
  - `CategoriesController`
  - Routes
  - Request specs

## Implementation Details
- **Controller Actions:**
  - `index`: Returns all categories.
  - `show`: Returns a specific category with its subcategories.
  - `create`: Handles category creation with validations.
  - `update`: Updates category details with validations.
  - `destroy`: Deletes a category and handles associated cleanup.
- **Routes:** 
  - Added RESTful routes for categories.
- **Request Specs:** 
  - Comprehensive tests for all endpoints to verify correct functionality and responses.
- **Factory Updates:**
  - Updated `categories` factory to ensure unique category names.

## How Has This Been Tested?
- [x] Request specs for all CRUD actions:
  - Verified successful operations (e.g., creating, updating, retrieving, and deleting categories).
  - Verified failure responses for invalid operations (e.g., missing parameters or nonexistent IDs).
- [x] Tested using Postman to confirm API behavior matches expectations.

## Checklist
- [x] Feature meets acceptance criteria
- [x] Tests are added and pass
- [x] Code follows project style guidelines
- [x] Documentation updated if needed
