### PR TITLE
feat: Implement JWT expiration and revocation handling

### DIFF
--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -2,15 +2,18 @@ require 'jwt'
 
 class JsonWebToken
   SECRET_KEY = ENV.fetch('JWT_SECRET_KEY')
+  ALGORITHM = 'HS256'.freeze
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i
-    JWT.encode(payload, SECRET_KEY)
+    payload[:jti] = SecureRandom.uuid
+    JWT.encode(payload, SECRET_KEY, ALGORITHM)
   end
 
   def self.decode(token)
-    body = JWT.decode(token, SECRET_KEY)[0]
-    return if JwtDenylist.exists?(jti: body['jti'])
+    body = JWT.decode(token, SECRET_KEY, true, algorithm: ALGORITHM)[0]
+    return nil if body['exp'].to_i < Time.now.to_i
+    return nil if body['jti'].nil? || JwtDenylist.exists?(jti: body['jti'])
 
     HashWithIndifferentAccess.new(body)
   rescue JWT::ExpiredSignature, JWT::DecodeError

--- a/spec/lib/json_web_token_spec.rb
+++ b/spec/lib/json_web_token_spec.rb
@@ -1,31 +1,52 @@
 require 'rails_helper'
-require 'json_web_token'
 
 RSpec.describe JsonWebToken do
   let(:payload) { { user_id: 1 } }
   let(:token) { described_class.encode(payload) }
 
   describe '.encode' do
-    it 'returns a valid JWT token' do
-      expect(token).not_to be_nil
-      expect(token).to be_a(String)
+    it 'creates a token with an expiration time and JTI' do
+      decoded = described_class.decode(token)
+
+      expect(decoded['exp']).to be_present
+      expect(decoded['jti']).to be_present
     end
   end
 
   describe '.decode' do
-    it 'decodes a valid token' do
-      decoded_payload = described_class.decode(token)
-      expect(decoded_payload['user_id']).to eq(payload[:user_id])
+    context 'with a valid token' do
+      it 'returns the payload' do
+        decoded = described_class.decode(token)
+
+        expect(decoded).to include('user_id' => 1)
+      end
     end
 
-    it 'returns nil for an invalid token' do
-      expect(described_class.decode('invalid_token')).to be_nil
+    context 'with an expired token' do
+      it 'returns nil' do
+        expired_token = described_class.encode(payload, 1.second.ago)
+        sleep(2) # Ensure token is expired
+        decoded = described_class.decode(expired_token)
+
+        expect(decoded).to be_nil
+      end
     end
 
-    it 'returns nil for an expired token' do
-      expired_token = described_class.encode(payload, 1.second.ago)
-      sleep 2
-      expect(described_class.decode(expired_token)).to be_nil
+    context 'with a revoked token' do
+      it 'returns nil' do
+        decoded_payload = described_class.decode(token)
+        JwtDenylist.create!(jti: decoded_payload['jti'], exp: Time.zone.at(decoded_payload['exp']))
+
+        expect(described_class.decode(token)).to be_nil
+      end
+    end
+
+    context 'with an invalid token' do
+      it 'returns nil' do
+        invalid_token = 'invalid.token.value'
+
+        expect(described_class.decode(invalid_token)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## **Closes #58 (Step 3)**  

### **Summary**  
This PR finalizes the JWT token management system by implementing expiration handling and denylist verification. Tokens now include a unique identifier (`jti`) and are checked against the denylist on decode. Expired tokens are automatically rejected.

### **Changes Made**  
- **Updated `JsonWebToken` class**:  
  - Tokens now include a **JTI (`jti`)** for revocation tracking.  
  - Expiration is enforced—**expired tokens are rejected**.  
  - The denylist is checked on decode, **blocking revoked tokens**.  

- **Updated tests (`json_web_token_spec.rb`)**:  
  - Ensure tokens contain a **JTI** and **expire properly**.  
  - Test denylist behavior to **reject revoked tokens**.  

### **How Has This Been Tested?**  
- ✅ **Unit tests** confirm that:  
  - Expired tokens return `nil` when decoded.  
  - Revoked tokens are blocked by the denylist.  
  - Valid tokens continue to function as expected.  
- ✅ **Manual verification** with encoded & revoked tokens.  

### **Checklist**  
- [x] Feature meets acceptance criteria  
- [x] Tests cover expected behavior  
- [x] Code follows project style guidelines
