### PR TITLE
fix: Ensure `authorize_request` before_action properly handles token …

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,42 @@
+class SessionsController < ApplicationController
+  before_action :authorize_request, only: [:logout]
+
+  def login
+    user = User.find_by(email: params[:email])
+
+    if user&.authenticate(params[:password])
+      token = JsonWebToken.encode(user_id: user.id)
+      render json: { token: token }, status: :ok
+    else
+      render json: { error: 'Invalid email or password' }, status: :unauthorized
+    end
+  end
+
+  def logout
+    token = request.headers['Authorization']&.split(' ')&.last
+    decoded_token = JsonWebToken.decode(token)
+
+    if decoded_token
+      JwtDenylist.create!(jti: decoded_token['jti'], exp: Time.zone.at(decoded_token['exp']))
+      render json: { message: 'Logged out successfully' }, status: :no_content
+    else
+      render json: { error: 'Invalid token' }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def authorize_request
+    token = request.headers['Authorization']&.split(' ')&.last
+    decoded_token = JsonWebToken.decode(token)
+
+    if decoded_token.nil? || JwtDenylist.exists?(jti: decoded_token['jti'])
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+      return
+    end
+
+    @current_user = User.find(decoded_token['user_id'])
+  rescue JWT::DecodeError, JWT::ExpiredSignature, ActiveRecord::RecordNotFound
+    render json: { error: 'Unauthorized' }, status: :unauthorized
+  end
+end


### PR DESCRIPTION
## **Fix: Ensure `authorize_request` Before Action Properly Handles Token Validation**

### **🔹 Summary**
This PR updates the `authorize_request` before action in `SessionsController` to ensure that authentication errors are handled consistently when validating JWT tokens.

### **🔹 Changes Made**
- Updated `authorize_request` to properly handle:
  - `JWT::DecodeError`
  - `JWT::ExpiredSignature`
  - `ActiveRecord::RecordNotFound`
- Ensured that invalid or missing tokens return an unauthorized response.
- Improved consistency in token validation across authentication flows.

### **🔹 How Has This Been Tested?**
✅ **Manual Testing**
- Sent requests with valid, expired, and revoked JWT tokens to verify correct responses.
- Confirmed that an unauthorized response is returned for invalid or missing tokens.

✅ **Automated Tests**
- Verified existing tests cover cases for:
  - ✅ Valid token authentication.
  - ✅ Expired token rejection.
  - ✅ Unauthorized response for missing or revoked tokens.

### **🔹 Checklist**
- [x] Feature meets acceptance criteria
- [x] Tests are passing
- [x] Code follows project style guidelines
- [x] Documentation updated if needed

closes #57
